### PR TITLE
주문 생성 요청시 첫번째 주문 상품의 이미지를 주문(Order)엔티티의 주문 대표 이미지(orderThumbnailUrl)로 설정하여 저장

### DIFF
--- a/src/main/java/com/ming/mingcommerce/cart/repository/CartRepository.java
+++ b/src/main/java/com/ming/mingcommerce/cart/repository/CartRepository.java
@@ -61,4 +61,13 @@ public interface CartRepository extends JpaRepository<Cart, String> {
             """)
     List<Boolean> isCartLineUuidDeleted(@Param("cartLineUuidList") List<String> cartLineUuidList);
 
+    @Query("""
+            SELECT p.thumbnailImageUrl
+            FROM Cart c
+            JOIN c.cartLines cl
+            JOIN Product p
+                ON p.productId = cl.productId
+                where cl.uuid = (:firstCartLineUuid)
+            """)
+    String getRepresentProductImageUrl(String firstCartLineUuid);
 }

--- a/src/main/java/com/ming/mingcommerce/order/entity/Order.java
+++ b/src/main/java/com/ming/mingcommerce/order/entity/Order.java
@@ -31,6 +31,9 @@ public class Order extends BaseTimeEntity {
     // 주문 이름
     private String orderName;
 
+    // 주문 대표 이미지 썸네일 URL. 첫번째 주문 상품의 이미지의 URL.
+    private String orderThumbnailUrl;
+
     @ElementCollection
     @OrderColumn(name = "line_idx")
     @CollectionTable(name = "order_line", joinColumns = @JoinColumn(name = "order_id"))
@@ -38,11 +41,12 @@ public class Order extends BaseTimeEntity {
 
     private Double totalAmount; // 총 주문 금액
 
-    public static Order create(Member member, List<OrderLine> orderLines) {
+    public static Order create(Member member, List<OrderLine> orderLines, String representProductImageUrl) {
         Double totalAmount = calculateTotalAmount(orderLines);
         String orderName = extractOrderName(orderLines);
         return Order.builder()
                 .member(member)
+                .orderThumbnailUrl(representProductImageUrl)
                 .orderStatus(OrderStatus.PENDING)
                 .totalAmount(totalAmount)
                 .orderName(orderName)
@@ -62,7 +66,7 @@ public class Order extends BaseTimeEntity {
         if (firstProductName.length() > 100) firstProductName = firstProductName.substring(0, 90);
         String shortenFirstProductName = firstProductName + "...";
         return orderLines.size() > 1 ?
-                shortenFirstProductName + " 외 " + orderLines.size() + "건" :
+                shortenFirstProductName + " 외 " + (orderLines.size() - 1) + "건" :
                 shortenFirstProductName;
     }
 

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderRequest.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderRequest.java
@@ -22,7 +22,7 @@ public class OrderRequest {
 
     public String extractFirstCartLineUuid() {
         String s = cartLineUuidList.get(0);
-        if (!StringUtils.hasText(s)) throw new IllegalArgumentException();
+        if (!StringUtils.hasText(s)) throw new IllegalArgumentException("카트 상품 UUID 가 존재하지 않습니다.");
         return s;
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderRequest.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,5 +18,11 @@ public class OrderRequest {
 
     public void addCartLineUuid(List<String> uuidList) {
         cartLineUuidList.addAll(uuidList);
+    }
+
+    public String extractFirstCartLineUuid() {
+        String s = cartLineUuidList.get(0);
+        if (!StringUtils.hasText(s)) throw new IllegalArgumentException();
+        return s;
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderResponse.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderResponse.java
@@ -11,5 +11,5 @@ public class OrderResponse {
     private String orderId;
     private Double amount;
     private String orderName;
-    private String thumbnailImageUrl;
+    private String orderThumbnailUrl;
 }

--- a/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
+++ b/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
@@ -40,12 +40,16 @@ public class OrderService {
 
         // 주문 라인 생성
         List<OrderLine> orderLines = createOrderLines(orderRequest.getCartLineUuidList());
+
+        // 주문 대표 이미지 가져오기
+        String firstCartLineUuid = orderRequest.extractFirstCartLineUuid();
+        String representProductImageUrl = cartRepository.getRepresentProductImageUrl(firstCartLineUuid);
         // 주문 생성
-        Order order = Order.create(member, orderLines);
+        Order order = Order.create(member, orderLines, representProductImageUrl);
         // 주문 저장
         orderRepository.save(order);
 
-        return new OrderResponse(order.getOrderId(), order.getTotalAmount(), order.getOrderName(), null);
+        return new OrderResponse(order.getOrderId(), order.getTotalAmount(), order.getOrderName(), orderRequest.extractFirstCartLineUuid());
     }
 
     private List<OrderLine> createOrderLines(List<String> cartLineUuidList) {

--- a/src/test/java/com/ming/mingcommerce/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/ming/mingcommerce/order/controller/OrderControllerTest.java
@@ -86,6 +86,8 @@ class OrderControllerTest extends BaseControllerTest {
                 ).andExpect(status().isOk())
                 .andExpect(jsonPath("orderId").exists())
                 .andExpect(jsonPath("amount").exists())
+                .andExpect(jsonPath("orderName").exists())
+                .andExpect(jsonPath("orderThumbnailUrl").exists())
                 .andDo(document("order",
                         requestHeaders(headerWithName(X_WWW_MING_AUTHORIZATION).description("인증 헤더")
                         ),
@@ -96,7 +98,7 @@ class OrderControllerTest extends BaseControllerTest {
                                 fieldWithPath("orderId").description("주문 아이디"),
                                 fieldWithPath("amount").description("주문 총 합계"),
                                 fieldWithPath("orderName").description("'[상품이름]외 [주문상품개수]건' 형식의 주문 이름"),
-                                fieldWithPath("thumbnailImageUrl").description("주문 썸네일 이미지 URL. 사용자 주문 조회 요청이 아닐 시 null 값이다.")
+                                fieldWithPath("orderThumbnailUrl").description("주문 썸네일 이미지 URL. 사용자 주문 조회 요청이 아닐 시 null 값이다.")
                         )
 
                 ))
@@ -127,7 +129,7 @@ class OrderControllerTest extends BaseControllerTest {
                                 fieldWithPath("orderId").description("주문 ID"),
                                 fieldWithPath("orderName").description("주문 이름. 2건 이상시 첫번째 상품 이름에 '외 n 건' 을 붙여 저장한다"),
                                 fieldWithPath("amount").description("총 결제 금액"),
-                                fieldWithPath("thumbnailImageUrl").description("주문 썸네일 이미지 URL. 사용자 주문 조회 요청이 아닐 시 null 값이다.")
+                                fieldWithPath("orderThumbnailUrl").description("주문 썸네일 이미지 URL. 사용자 주문 조회 요청이 아닐 시 null 값이다.")
                         )
                 ))
 


### PR DESCRIPTION
## 개발 상세 내용

**주문 생성 요청**시 첫번째 주문 상품의 이미지를 주문(`Order`)엔티티의 주문 대표 이미지(`orderThumbnailUrl`)로 설정하여 저장합니다. 이를 통해 추후 사용자 주문 조회시 주문 대표이미지를 위한 상품(`Product`) 엔티티와의 조인이 필요하지 않아 성능 향상과 개발의 편의성을 기대할 수 있습니다.

Order 엔티티의 스키마의 변경(`orderThumbnailUrl` 속성 추가)으로 인해 테스트시 **기존의 데이터를 삭제하시고, 새로 스키마를 `create`하신 후 실행해주시기 바랍니다.**

상품 INSERT DML 은 `공유 메모`에 적어두었습니다. 빠른 시일 내에 아마존닷컴 크롤링 이슈 해결하겠습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [MING-70](https://ming-commerce.atlassian.net/jira/software/projects/MING/boards/4/roadmap?selectedIssue=MING-70)

## 테스트 방법을 적습니다.(필요시)

어떻게 테스트를 진행해야 하는지 적습니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11


[MING-70]: https://ming-commerce.atlassian.net/browse/MING-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ