### PR TITLE
메일 인증과 유저 이메일 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("com.auth0:java-jwt:4.2.1")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.modelmapper:modelmapper:3.1.1")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")
@@ -50,6 +51,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("org.springframework.security:spring-security-test")
+
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
 }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -37,6 +37,19 @@ operation::login[]
 
 operation::get-member-info[]
 
+=== 이메일 변경을 위한 이메일 전송
+
+변경을 원하는 이메일로 이메일을 전송한다.
+인증을 위한 링크에는 UUID 형식의 토큰과 변경하기 원하는 이메일이 쿼리파리미터로 설정된다.
+
+operation::send-authentication-mail[]
+
+=== 이메일 인증 확인과 이메일 변경
+
+쿼리파리미터로 넘어온 토큰을 검증한 뒤, 이메일을 변경한다.
+
+operation::change-email[]
+
 == Product
 
 === 상품 데이터 삽입
@@ -109,6 +122,7 @@ operation::get-order-by-id[]
 operation::get-order-detail[]
 
 === 사용자의 주문 조회하기
+
 사용자의 주문을 페이징하여 조회한다.
 각 주문의 주문 아이디, 주문 이름, 총 결제 금액, 주문 이름, 주문썸네일, 주문생성일자를 반환한다.
 

--- a/src/main/java/com/ming/mingcommerce/mail/MailConfig.java
+++ b/src/main/java/com/ming/mingcommerce/mail/MailConfig.java
@@ -1,0 +1,36 @@
+package com.ming.mingcommerce.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public MailSender getMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+
+        mailSender.setUsername(sender);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/ming/mingcommerce/mail/MailService.java
+++ b/src/main/java/com/ming/mingcommerce/mail/MailService.java
@@ -1,0 +1,7 @@
+package com.ming.mingcommerce.mail;
+
+import com.ming.mingcommerce.security.CurrentMember;
+
+public interface MailService {
+    String sendMail(String emailTo, CurrentMember currentMember);
+}

--- a/src/main/java/com/ming/mingcommerce/mail/MailServiceImpl.java
+++ b/src/main/java/com/ming/mingcommerce/mail/MailServiceImpl.java
@@ -1,0 +1,42 @@
+package com.ming.mingcommerce.mail;
+
+import com.ming.mingcommerce.member.entity.Member;
+import com.ming.mingcommerce.member.repository.MemberRepository;
+import com.ming.mingcommerce.security.CurrentMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MailServiceImpl implements MailService {
+    private final MailConfig mailConfig;
+    private final MemberRepository memberRepository;
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+    @Value("${ming.domain}")
+    private String domainAddress;
+
+    @Override
+    @Transactional
+    public String sendMail(String emailTo, CurrentMember currentMember) {
+        // 메일 생성
+        MailSender mailSender = mailConfig.getMailSender();
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setFrom(senderEmail);
+        mailMessage.setTo(emailTo);
+        mailMessage.setSubject("[밍커머스] 이메일 변경을 위한 인증 메일 입니다.");
+        Member member = memberRepository.findMemberByEmail(currentMember.getEmail());
+
+        String authenticationLink = domainAddress + "/api/members" + "?token=" + member.getEmailCheckToken() + "&newEmail=" + emailTo;
+        mailMessage.setText("[밍커머스 인증하기]" + authenticationLink);
+        mailSender.send(mailMessage);
+
+        return "success";
+    }
+
+}

--- a/src/main/java/com/ming/mingcommerce/member/controller/MemberController.java
+++ b/src/main/java/com/ming/mingcommerce/member/controller/MemberController.java
@@ -1,12 +1,12 @@
 package com.ming.mingcommerce.member.controller;
 
 import com.ming.mingcommerce.member.exception.MemberException;
-import com.ming.mingcommerce.member.model.MemberModel;
-import com.ming.mingcommerce.member.model.RegisterRequest;
-import com.ming.mingcommerce.member.model.RegisterResponse;
+import com.ming.mingcommerce.member.model.*;
 import com.ming.mingcommerce.member.service.MemberService;
+import com.ming.mingcommerce.security.CurrentMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -43,5 +43,38 @@ public class MemberController {
     public ResponseEntity<?> getMemberInfo(Authentication authentication) {
         MemberModel memberModel = memberService.getMemberInfo(authentication);
         return new ResponseEntity<>(Map.of("result", memberModel), HttpStatus.OK);
+    }
+
+    /**
+     * 유저가 이메일 변경을 위해 변경하고 싶은 이메일을 전송한다. 이메일 확인을 위해 해당 이메일로 인증메일을 전송한다.
+     *
+     * @param request 변경을 요청하는 이메일
+     * @return 상태코드 200 일시 성공적으로 이메일이 전송됨
+     */
+    @PostMapping("/send-email")
+    public ResponseEntity<?> sendEmailForChangeEmail(@RequestBody MemberEmailAuthenticationRequest request, Authentication authentication) {
+        if (!(authentication.getPrincipal() instanceof CurrentMember currentMember))
+            throw new IllegalArgumentException();
+        memberService.sendEmail(request.getEmail(), currentMember);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * 이메일 인증 성공시 유저의 이메일을 변경한다.
+     *
+     * @param token          유저 인증을 위한 UUID 형식의 토큰
+     * @param newEmail       변경을 원하는 이메일
+     * @param authentication 인증 객체
+     * @return 변경된 이메일로 새로 발급한 access token 과 refresh token
+     */
+    @GetMapping("/change-email")
+    public ResponseEntity<?> changeEmail(@Param("token") String token,
+                                         @Param("newEmail") String newEmail,
+                                         Authentication authentication) {
+        if (!(authentication.getPrincipal() instanceof CurrentMember currentMember))
+            throw new IllegalArgumentException();
+        JwtTokenModel tokenModel = memberService.changeEmail(token, newEmail, currentMember);
+        // 새로운 액세스토큰과 리프레시 토큰 발급하여 반환
+        return new ResponseEntity<>(tokenModel, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/ming/mingcommerce/member/entity/Member.java
+++ b/src/main/java/com/ming/mingcommerce/member/entity/Member.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @Builder
@@ -21,9 +23,19 @@ public class Member extends BaseTimeEntity {
     private String memberName;
     @Enumerated(EnumType.STRING)
     private Role role = Role.USER;
+    private String emailCheckToken;
 
     public void setAdminRole() {
         this.role = Role.ADMIN;
+    }
+
+    public void generateEmailAuthenticationToken() {
+        this.emailCheckToken = UUID.randomUUID().toString();
+    }
+
+    public Member changeEmail(String email) {
+        this.email = email;
+        return this;
     }
 
 }

--- a/src/main/java/com/ming/mingcommerce/member/exception/MemberException.java
+++ b/src/main/java/com/ming/mingcommerce/member/exception/MemberException.java
@@ -34,4 +34,16 @@ public class MemberException extends RuntimeException {
             super(message);
         }
     }
+
+    public static class CurrentlyInUseEmailException extends MemberException {
+        public CurrentlyInUseEmailException(String message) {
+            super(message);
+        }
+    }
+
+    public static class WrongTokenException extends MemberException {
+        public WrongTokenException(String message) {
+            super(message);
+        }
+    }
 }

--- a/src/main/java/com/ming/mingcommerce/member/model/MemberEmailAuthenticationRequest.java
+++ b/src/main/java/com/ming/mingcommerce/member/model/MemberEmailAuthenticationRequest.java
@@ -1,0 +1,12 @@
+package com.ming.mingcommerce.member.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberEmailAuthenticationRequest {
+    private String email;
+}

--- a/src/main/resources/application-default.yml
+++ b/src/main/resources/application-default.yml
@@ -11,6 +11,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  mail:
+    username: ${MING_MAIL_SENDER_EMAIL} # TODO 테스트를 위해서는 개인 이메일 계정을 환경변수에 세팅해주세요. 추후 밍커머스 이메일 계정으로 바꾸어야 합니다.
+    password: ${MING_MAIL_SENDER_PASSWORD}
 
 jwt:
   access-token-duration: 604800000 # valid 1 Week
@@ -24,3 +27,6 @@ admin:
 toss:
   payments:
     secret-key: ${TOSS_SECRET_KEY}
+
+ming:
+  domain: https://api.mingcommerce.net

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  mail:
+    username: test@tester.com
+    password: password
 
 
 jwt:
@@ -26,3 +29,6 @@ admin:
 toss:
   payments:
     secret-key: toss-test-secret-key
+
+ming:
+  domain: http://localhost:8080


### PR DESCRIPTION
## 개발 상세 내용

유저 이메일 변경을 위해 이메일 인증을 진행합니다. 인증이 성공적으로 되어야만 이메일을 변경할 수 있습니다. 현재 동기 방식으로 이메일을 전송하고 있습니다. 현재 기능 검토 받고, 비동기로 처리할 수 있는 방법([람다](https://docs.spring.io/spring-cloud-function/docs/current/reference/html/aws.html), `@Async`)으로 바꿀 예정입니다.

## Jira Ticket

- [MING-72](https://ming-commerce.atlassian.net/browse/MING-72)

## 테스트 방법을 적습니다.
**MemberControllerTest**#`sendAuthenticationEmail_Success`
**MemberControllerTest**#`changeEmail_Success`


## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11


[MING-72]: https://ming-commerce.atlassian.net/browse/MING-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ