### PR TITLE
Feature/ming 81 주문 상세 조회 이슈

### DIFF
--- a/src/main/java/com/ming/mingcommerce/order/controller/OrderController.java
+++ b/src/main/java/com/ming/mingcommerce/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package com.ming.mingcommerce.order.controller;
 
 import com.ming.mingcommerce.member.entity.Member;
-import com.ming.mingcommerce.order.model.OrderDetail;
+import com.ming.mingcommerce.order.model.OrderProductDetail;
 import com.ming.mingcommerce.order.model.OrderRequest;
 import com.ming.mingcommerce.order.model.OrderResponse;
 import com.ming.mingcommerce.order.service.OrderService;
@@ -14,8 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -75,18 +73,18 @@ public class OrderController {
 
 
     /**
-     * 주문 상세를 조회한다
+     * 주문 상세를 조회한다.
      *
      * @param authentication
      * @param orderId
-     * @return orderDetail
+     * @return 주문 정보(주문이름, 주문총액, 주문날짜)와 주문상품 정보(상품아이디, 상품이름, 썸네일, 가격, 주문수량)를 반환한다.
      */
     @GetMapping("/order-detail")
     public ResponseEntity<?> getOrderDetail(Authentication authentication, @Param("orderId") String orderId) {
         if (!((authentication.getPrincipal()) instanceof CurrentMember currentMember)) {
             throw new IllegalArgumentException();
         }
-        List<OrderDetail> result = orderService.getOrderDetail(orderId, currentMember);
+        OrderProductDetail result = orderService.getOrderDetail(orderId, currentMember);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/controller/OrderController.java
+++ b/src/main/java/com/ming/mingcommerce/order/controller/OrderController.java
@@ -67,7 +67,7 @@ public class OrderController {
         if (!(authentication.getPrincipal() instanceof CurrentMember currentMember)) {
             throw new IllegalArgumentException();
         }
-        var myOrders = orderService.getMyOrder(currentMember, pageable);
+        var myOrders = orderService.getMyOrderList(currentMember, pageable);
         return new ResponseEntity<>(myOrders, HttpStatus.OK);
     }
 
@@ -84,7 +84,7 @@ public class OrderController {
         if (!((authentication.getPrincipal()) instanceof CurrentMember currentMember)) {
             throw new IllegalArgumentException();
         }
-        OrderProductDetail result = orderService.getOrderDetail(orderId, currentMember);
+        OrderProductDetail result = orderService.getOrderProductDetail(orderId, currentMember);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/entity/Order.java
+++ b/src/main/java/com/ming/mingcommerce/order/entity/Order.java
@@ -2,6 +2,7 @@ package com.ming.mingcommerce.order.entity;
 
 import com.ming.mingcommerce.config.BaseTimeEntity;
 import com.ming.mingcommerce.member.entity.Member;
+import com.ming.mingcommerce.order.model.OrderDetail;
 import com.ming.mingcommerce.order.vo.OrderLine;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -78,5 +79,9 @@ public class Order extends BaseTimeEntity {
 
     public void completePay() {
         this.orderStatus = OrderStatus.COMPLETE;
+    }
+
+    public OrderDetail toOrderDetail(Order order) {
+        return new OrderDetail(order);
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
@@ -1,5 +1,6 @@
 package com.ming.mingcommerce.order.model;
 
+import com.ming.mingcommerce.order.entity.Order;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,9 +18,9 @@ public class OrderDetail {
     private LocalDateTime createDate;
     private List<ProductDetail> productDetailList = new ArrayList<>();
 
-    public OrderDetail(String orderName, Double totalAmount, LocalDateTime createDate) {
-        this.orderName = orderName;
-        this.totalAmount = totalAmount;
-        this.createDate = createDate;
+    public OrderDetail(Order order) {
+        this.orderName = order.getOrderName();
+        this.totalAmount = order.getTotalAmount();
+        this.createDate = order.getCreatedDate();
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
@@ -3,16 +3,23 @@ package com.ming.mingcommerce.order.model;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderDetail {
-    private String productId;
-    private String productName;
-    private String thumbnailImageUrl;
-    private Double price;
-    private Long quantity;
+    private String orderName;
+    private Double totalAmount;
+    private LocalDateTime createDate;
+    private List<ProductDetail> productDetailList = new ArrayList<>();
+
+    public OrderDetail(String orderName, Double totalAmount, LocalDateTime createDate) {
+        this.orderName = orderName;
+        this.totalAmount = totalAmount;
+        this.createDate = createDate;
+    }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderDetail.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -16,11 +14,8 @@ public class OrderDetail {
     private String orderName;
     private Double totalAmount;
     private LocalDateTime createDate;
-    private List<ProductDetail> productDetailList = new ArrayList<>();
 
     public OrderDetail(Order order) {
-        this.orderName = order.getOrderName();
-        this.totalAmount = order.getTotalAmount();
-        this.createDate = order.getCreatedDate();
+        this(order.getOrderName(), order.getTotalAmount(), order.getCreatedDate());
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
@@ -13,13 +13,13 @@ import java.util.List;
 public class OrderProductDetail {
     private String orderName;
     private Double totalAmount;
-    private LocalDateTime createDate;
+    private LocalDateTime createdDate;
     private List<ProductDetail> productDetailList;
 
     public OrderProductDetail(OrderDetail orderDetail, List<ProductDetail> productDetailList) {
         this.orderName = orderDetail.getOrderName();
         this.totalAmount = orderDetail.getTotalAmount();
-        this.createDate = orderDetail.getCreateDate();
+        this.createdDate = orderDetail.getCreateDate();
         this.productDetailList = productDetailList;
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
@@ -1,0 +1,25 @@
+package com.ming.mingcommerce.order.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderProductDetail {
+    private String orderName;
+    private Double totalAmount;
+    private LocalDateTime createDate;
+    private List<ProductDetail> productDetailList;
+
+    public OrderProductDetail(OrderDetail orderDetail, List<ProductDetail> productDetailList) {
+        this.orderName = orderDetail.getOrderName();
+        this.totalAmount = orderDetail.getTotalAmount();
+        this.createDate = orderDetail.getCreateDate();
+        this.productDetailList = productDetailList;
+    }
+}

--- a/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/OrderProductDetail.java
@@ -17,9 +17,9 @@ public class OrderProductDetail {
     private List<ProductDetail> productDetailList;
 
     public OrderProductDetail(OrderDetail orderDetail, List<ProductDetail> productDetailList) {
-        this.orderName = orderDetail.getOrderName();
-        this.totalAmount = orderDetail.getTotalAmount();
-        this.createdDate = orderDetail.getCreateDate();
-        this.productDetailList = productDetailList;
+        this(orderDetail.getOrderName(),
+                orderDetail.getTotalAmount(),
+                orderDetail.getCreateDate(),
+                productDetailList);
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/model/ProductDetail.java
+++ b/src/main/java/com/ming/mingcommerce/order/model/ProductDetail.java
@@ -1,0 +1,18 @@
+package com.ming.mingcommerce.order.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDetail {
+    private String productId;
+    private String productName;
+    private String thumbnailImageUrl;
+    private Double price;
+    private Long quantity;
+}

--- a/src/main/java/com/ming/mingcommerce/order/respository/OrderRepository.java
+++ b/src/main/java/com/ming/mingcommerce/order/respository/OrderRepository.java
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, String> {
-    default Order findOrderByOrderId(String orderId) {
+    default Order findByOrderId(String orderId) {
         return findById(orderId).orElseThrow(EntityNotFoundException::new);
     }
 
@@ -76,7 +76,7 @@ public interface OrderRepository extends JpaRepository<Order, String> {
                 WHERE o.member.uuid = :memberUuid
                     AND o.orderStatus = 'COMPLETE'
             """)
-    Page<MyOrderModel> getMyOrder(String memberUuid, Pageable pageable);
+    Page<MyOrderModel> getMyOrderList(String memberUuid, Pageable pageable);
 
     // 주문 상세 조회
     default OrderProductDetail getMyOrderDetail(String orderId) {

--- a/src/main/java/com/ming/mingcommerce/order/respository/OrderRepository.java
+++ b/src/main/java/com/ming/mingcommerce/order/respository/OrderRepository.java
@@ -19,20 +19,6 @@ public interface OrderRepository extends JpaRepository<Order, String> {
     }
 
     /**
-     * 주문 상세를 위한 주문 정보를 조회한다.
-     * @param orderId
-     * @return 주문이름, 주문총액, 주문날짜
-     */
-    @Query("""
-            SELECT new com.ming.mingcommerce.order.model.OrderDetail(
-                o.orderName, o.totalAmount, o.createdDate
-            )
-            FROM Order o
-                WHERE o.orderId = :orderId
-            """)
-    OrderDetail getOrderDetail(String orderId);
-
-    /**
      * 주문 상세를 위한 주문상품 정보를 조회한다. 상품아이디, 상품이름, 썸네일, 주문상품가격, 주문상품수량을 반환한다.
      *
      * @param orderId
@@ -79,8 +65,9 @@ public interface OrderRepository extends JpaRepository<Order, String> {
     Page<MyOrderModel> getMyOrderList(String memberUuid, Pageable pageable);
 
     // 주문 상세 조회
-    default OrderProductDetail getMyOrderDetail(String orderId) {
-        OrderDetail orderDetail = getOrderDetail(orderId);
+    default OrderProductDetail getMyOrderProductDetail(String orderId) {
+        Order order = findByOrderId(orderId);
+        OrderDetail orderDetail = order.toOrderDetail(order);
         List<ProductDetail> productDetailList = getOrderProductDetail(orderId);
         return new OrderProductDetail(orderDetail, productDetailList);
     }

--- a/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
+++ b/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
@@ -60,7 +60,7 @@ public class OrderService {
 
     // 주문 조회시 해당 주문 조회 권한이 있는 요청인지 검증
     private void validate(CurrentMember currentMember, String orderId) {
-        Order order = orderRepository.findOrderByOrderId(orderId);
+        Order order = orderRepository.findByOrderId(orderId);
         if (!Objects.equals(order.getMember().getEmail(), currentMember.getEmail())) {
             throw new IllegalArgumentException("해당 주문을 조회할 수 있는 사용자가 아닙니다.");
         }
@@ -70,19 +70,19 @@ public class OrderService {
     public OrderResponse getOrder(String orderId, CurrentMember currentMember) {
         // 현재 요청의 사용자가 해당 주문을 조회할 수 있는지 검증
         validate(currentMember, orderId);
-        Order order = orderRepository.findOrderByOrderId(orderId);
+        Order order = orderRepository.findByOrderId(orderId);
         return modelMapper.map(order, OrderResponse.class);
     }
 
     // orderId 에 해당하는 주문 상세 조회
-    public OrderProductDetail getOrderDetail(String orderId, CurrentMember currentMember) {
+    public OrderProductDetail getOrderProductDetail(String orderId, CurrentMember currentMember) {
         // 현재 요청의 사용자가 해당 주문을 조회할 수 있는지 검증
         validate(currentMember, orderId);
         return orderRepository.getMyOrderDetail(orderId);
     }
 
     // 사용자의 전체 주문 조회
-    public PagingObject<MyOrderModel> getMyOrder(CurrentMember currentMember, Pageable pageable) {
-        return PagingObject.of(orderRepository.getMyOrder(currentMember.getUuid(), pageable));
+    public PagingObject<MyOrderModel> getMyOrderList(CurrentMember currentMember, Pageable pageable) {
+        return PagingObject.of(orderRepository.getMyOrderList(currentMember.getUuid(), pageable));
     }
 }

--- a/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
+++ b/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
@@ -78,7 +78,7 @@ public class OrderService {
     public OrderProductDetail getOrderProductDetail(String orderId, CurrentMember currentMember) {
         // 현재 요청의 사용자가 해당 주문을 조회할 수 있는지 검증
         validate(currentMember, orderId);
-        return orderRepository.getMyOrderDetail(orderId);
+        return orderRepository.getMyOrderProductDetail(orderId);
     }
 
     // 사용자의 전체 주문 조회

--- a/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
+++ b/src/main/java/com/ming/mingcommerce/order/service/OrderService.java
@@ -5,7 +5,7 @@ import com.ming.mingcommerce.cart.repository.CartRepository;
 import com.ming.mingcommerce.member.entity.Member;
 import com.ming.mingcommerce.order.entity.Order;
 import com.ming.mingcommerce.order.model.MyOrderModel;
-import com.ming.mingcommerce.order.model.OrderDetail;
+import com.ming.mingcommerce.order.model.OrderProductDetail;
 import com.ming.mingcommerce.order.model.OrderRequest;
 import com.ming.mingcommerce.order.model.OrderResponse;
 import com.ming.mingcommerce.order.respository.OrderRepository;
@@ -75,10 +75,10 @@ public class OrderService {
     }
 
     // orderId 에 해당하는 주문 상세 조회
-    public List<OrderDetail> getOrderDetail(String orderId, CurrentMember currentMember) {
+    public OrderProductDetail getOrderDetail(String orderId, CurrentMember currentMember) {
         // 현재 요청의 사용자가 해당 주문을 조회할 수 있는지 검증
         validate(currentMember, orderId);
-        return orderRepository.getOrderDetail(orderId);
+        return orderRepository.getMyOrderDetail(orderId);
     }
 
     // 사용자의 전체 주문 조회

--- a/src/main/java/com/ming/mingcommerce/payment/service/TossPaymentService.java
+++ b/src/main/java/com/ming/mingcommerce/payment/service/TossPaymentService.java
@@ -37,7 +37,7 @@ public class TossPaymentService implements PaymentService {
         PaymentApprovalResponse response = tossPaymentApprovalApi.processPay(request);
         // 결제 히스토리 저장
         savePaymentHistory(response);
-        Order order = orderRepository.findOrderByOrderId(response.getOrderId());
+        Order order = orderRepository.findByOrderId(response.getOrderId());
         // 주문 상태 바꾸기 PENDING -> COMPLETE
         successPay(order, currentMember);
         return response;
@@ -53,7 +53,7 @@ public class TossPaymentService implements PaymentService {
 
     // 결제 요청 금액과 주문 금액이 같은지 검증
     private void validateAmount(PaymentApprovalRequest request) {
-        Order order = orderRepository.findOrderByOrderId(request.getOrderId());
+        Order order = orderRepository.findByOrderId(request.getOrderId());
         order.validateAmount(request.getAmount());
     }
 

--- a/src/test/java/com/ming/mingcommerce/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/ming/mingcommerce/order/controller/OrderControllerTest.java
@@ -148,11 +148,15 @@ class OrderControllerTest extends BaseControllerTest {
                         .queryParam("orderId", orderResponse.getOrderId())
                         .header(X_WWW_MING_AUTHORIZATION, jwtTokenUtil.issueToken(member).getAccessToken()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[*].productId").exists())
-                .andExpect(jsonPath("$[*].productName").exists())
-                .andExpect(jsonPath("$[*].thumbnailImageUrl").exists())
-                .andExpect(jsonPath("$[*].price").exists())
-                .andExpect(jsonPath("$[*].quantity").exists())
+                .andExpect(jsonPath("orderName").exists())
+                .andExpect(jsonPath("totalAmount").exists())
+                .andExpect(jsonPath("createdDate").exists())
+                .andExpect(jsonPath("productDetailList").exists())
+                .andExpect(jsonPath("$.productDetailList[0].productId").exists())
+                .andExpect(jsonPath("$.productDetailList[0].productName").exists())
+                .andExpect(jsonPath("$.productDetailList[0].thumbnailImageUrl").exists())
+                .andExpect(jsonPath("$.productDetailList[0].price").exists())
+                .andExpect(jsonPath("$.productDetailList[0].quantity").exists())
                 .andDo(document("get-order-detail",
                         requestHeaders(
                                 headerWithName(X_WWW_MING_AUTHORIZATION).description("인증 헤더")
@@ -161,11 +165,15 @@ class OrderControllerTest extends BaseControllerTest {
                                 parameterWithName("orderId").description("주문 아이디")
                         ),
                         responseFields(
-                                fieldWithPath("[].productId").description("상품 아이디"),
-                                fieldWithPath("[].productName").description("상품명"),
-                                fieldWithPath("[].thumbnailImageUrl").description("상품 썸네일 URL"),
-                                fieldWithPath("[].price").description("상품 가격"),
-                                fieldWithPath("[].quantity").description("상품 주문 수량")
+                                fieldWithPath("orderName").description("주문이름"),
+                                fieldWithPath("totalAmount").description("총주문금액"),
+                                fieldWithPath("createdDate").description("주문날짜"),
+                                fieldWithPath("productDetailList").description("주문상품리스트"),
+                                fieldWithPath("productDetailList[].productId").description("상품 아이디"),
+                                fieldWithPath("productDetailList[].productName").description("상품명"),
+                                fieldWithPath("productDetailList[].thumbnailImageUrl").description("상품 썸네일 URL"),
+                                fieldWithPath("productDetailList[].price").description("상품 가격"),
+                                fieldWithPath("productDetailList[].quantity").description("상품 주문 수량")
                         )
                 ))
         ;

--- a/src/test/java/com/ming/mingcommerce/payment/service/TossPaymentServiceTest.java
+++ b/src/test/java/com/ming/mingcommerce/payment/service/TossPaymentServiceTest.java
@@ -76,7 +76,7 @@ class TossPaymentServiceTest extends BaseServiceTest {
         Order order = orderRepository.findById(orderId).orElseThrow(EntityNotFoundException::new);
         assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.COMPLETE);
         // 주문이 완료되었으므로 카트라인의 삭제 여부가 true 로 변경된다
-        Order savedOrder = orderRepository.findOrderByOrderId(orderId);
+        Order savedOrder = orderRepository.findByOrderId(orderId);
         List<String> cartLineUuidList = savedOrder.getOrderLineList().stream().map(OrderLine::getCartLineUuid).toList();
         List<Boolean> cartLineDTOList = cartRepository.isCartLineUuidDeleted(cartLineUuidList);
         assertThat(cartLineDTOList.stream().allMatch((Boolean::booleanValue))).isTrue();


### PR DESCRIPTION
## 개발 상세 내용

`orderId` 에 해당하는 주문 상세 조회시, 주문상품들에 대한 리스트 정보함께 가져오려했으나, jpql 에서 chlid collection 을 가져올 수 없는 한계가 있었습니다.

차선책으로, 우선 orderId 를 사용하여 주문에 대한 정보(주문이름, 주문총액, 주문날짜)를 가져온 다음, 주문 상품에 대한 쿼리를 한번 더 날려 이를 자바 애플리케이션 상에서 조합하여 반환하는 형식을 사용했습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [MING-81](https://ming-commerce.atlassian.net/browse/MING-81)

## 테스트 방법을 적습니다.(필요시)

어떻게 테스트를 진행해야 하는지 적습니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11


[MING-81]: https://ming-commerce.atlassian.net/browse/MING-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ